### PR TITLE
Add build script for Windows clock executable

### DIFF
--- a/build_exe.bat
+++ b/build_exe.bat
@@ -1,0 +1,2 @@
+@echo off
+pyinstaller --onefile --windowed --name AnalogClock clock.py

--- a/clock.py
+++ b/clock.py
@@ -1,0 +1,61 @@
+import tkinter as tk
+import math
+import datetime
+
+WIDTH = 300
+HEIGHT = 300
+CENTER_X = WIDTH // 2
+CENTER_Y = HEIGHT // 2
+RADIUS = min(WIDTH, HEIGHT) // 2 - 10
+
+class Clock(tk.Canvas):
+    def __init__(self, master=None, **kwargs):
+        super().__init__(master, width=WIDTH, height=HEIGHT, bg='white', highlightthickness=0, **kwargs)
+        self.pack()
+        self.draw_face()
+        self.hour_hand = self.create_line(CENTER_X, CENTER_Y, CENTER_X, CENTER_Y - RADIUS*0.5, width=4, fill='black')
+        self.minute_hand = self.create_line(CENTER_X, CENTER_Y, CENTER_X, CENTER_Y - RADIUS*0.75, width=2, fill='black')
+        self.second_hand = self.create_line(CENTER_X, CENTER_Y, CENTER_X, CENTER_Y - RADIUS*0.9, width=1, fill='red')
+        self.update_clock()
+
+    def draw_face(self):
+        self.create_oval(CENTER_X - RADIUS, CENTER_Y - RADIUS, CENTER_X + RADIUS, CENTER_Y + RADIUS, width=2)
+        for i in range(12):
+            angle = math.pi / 6 * i
+            x_inner = CENTER_X + RADIUS * 0.85 * math.sin(angle)
+            y_inner = CENTER_Y - RADIUS * 0.85 * math.cos(angle)
+            x_outer = CENTER_X + RADIUS * math.sin(angle)
+            y_outer = CENTER_Y - RADIUS * math.cos(angle)
+            self.create_line(x_inner, y_inner, x_outer, y_outer, width=2)
+
+    def update_clock(self):
+        now = datetime.datetime.now()
+        sec = now.second
+        minute = now.minute + sec / 60
+        hour = now.hour % 12 + minute / 60
+
+        sec_angle = math.pi / 30 * sec
+        min_angle = math.pi / 30 * minute
+        hour_angle = math.pi / 6 * hour
+
+        self._update_hand(self.second_hand, sec_angle, RADIUS * 0.9)
+        self._update_hand(self.minute_hand, min_angle, RADIUS * 0.75)
+        self._update_hand(self.hour_hand, hour_angle, RADIUS * 0.5)
+
+        self.after(1000, self.update_clock)
+
+    def _update_hand(self, hand, angle, length):
+        x = CENTER_X + length * math.sin(angle)
+        y = CENTER_Y - length * math.cos(angle)
+        self.coords(hand, CENTER_X, CENTER_Y, x, y)
+
+
+def main():
+    root = tk.Tk()
+    root.title("Analog Clock")
+    root.attributes('-topmost', True)
+    Clock(root)
+    root.mainloop()
+
+if __name__ == '__main__':
+    main()

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,26 @@
-test
+# Analog Clock App
+
+This repository contains a simple desktop application that displays an analog clock using Tkinter.
+
+## Build a Windows Executable
+If you want to run the clock without invoking Python directly, you can bundle it into an `.exe` with [PyInstaller](https://pyinstaller.org/):
+
+1. Install PyInstaller: `pip install pyinstaller`
+2. Run the provided batch script:
+
+   ```
+   build_exe.bat
+   ```
+
+   This creates `dist/AnalogClock.exe`, a standalone executable.
+3. Double-click `AnalogClock.exe` to launch the clock.
+
+## Development from Source (optional)
+To run the script directly during development:
+
+```
+python clock.py
+```
+
+This opens a window with a circular clock showing the current time.
+The clock window is configured to stay on top of other windows so it remains visible.


### PR DESCRIPTION
## Summary
- add `build_exe.bat` to bundle the analog clock into a Windows `.exe` via PyInstaller
- document executable build and usage steps in the README while keeping optional source instructions
- keep the analog clock window always on top of other applications

## Testing
- `python clock.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb62cbcc0832f91dd539334a0c654